### PR TITLE
fix: check expiration date in isLoggedIn

### DIFF
--- a/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
+++ b/projects/fusionauth-angular-sdk/src/lib/fusion-auth.service.ts
@@ -56,7 +56,7 @@ export class FusionAuthService {
    * @return {boolean} app.at_exp is present and not for a time in the past
    */
   isLoggedIn(): boolean {
-    return !!this.getExpTime();
+    return (this.getExpTime() ?? 0) > new Date().getTime();
   }
 
   /**


### PR DESCRIPTION
Currently `isLoggedIn()` only checks if the `app.at_exp` cookie is set, and not if it's already expired.