### PR TITLE
Fix GitHub publish Action directory route

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build-sdk
+      - run: cd dist/fusionauth-angular-sdk
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What is this PR and why do we need it?

We need to adjust the directory from which we will run the `npm publish` command in order to deploy the package.
