### PR TITLE
:memo: Adding upgrade policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ An SDK for using FusionAuth in Angular applications.
 
 -   [Releases](#releases)
 
+-   [Upgrade Policy](#upgrade-policy)
+
 <!--
 this tag, and the corresponding end tag, are used to delineate what is pulled into the FusionAuth docs site (the client libraries pages). Don't remove unless you also change the docs site.
 
@@ -222,3 +224,11 @@ Use backticks for code in this readme. This readme is included on the FusionAuth
 ## Releases
 
 To perform a release to NPM, create a release on GitHub. That will automatically publish a release to GitHub.
+
+## Upgrade Policy
+
+This library may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we\'ll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
+
+This means that after a dependency (e.g. language, framework, or operating system) is deprecated by its maintainer, this library will also be deprecated by us, and may eventually be updated to use a newer version.

--- a/generated/README.adoc
+++ b/generated/README.adoc
@@ -13,6 +13,7 @@ An SDK for using FusionAuth in Angular applications.
 * <<quickstart,Quickstart>>
 * <<documentation,Documentation>>
 * <<releases,Releases>>
+* <<upgrade-policy,Upgrade Policy>>
 
 ////
 this tag, and the corresponding end tag, are used to delineate what is pulled into the FusionAuth docs site (the client libraries pages). Don't remove unless you also change the docs site.
@@ -213,3 +214,11 @@ Use backticks for code in this readme. This readme is included on the FusionAuth
 === Releases
 
 To perform a release to NPM, create a release on GitHub. That will automatically publish a release to GitHub.
+
+=== Upgrade Policy
+
+This library may periodically receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we'll follow the deprecation and sunsetting policies of the underlying technologies that the libraries use.
+
+This means that after a dependency (e.g. language, framework, or operating system) is deprecated by its maintainer, this library will also be deprecated by us, and may eventually be updated to use a newer version.


### PR DESCRIPTION
## What is this PR and why do we need it?

Adding the "Upgrade Policy" section as [described here](https://github.com/FusionAuth/fusionauth-site/pull/2916).