### PR TITLE
Adding archival note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This repo is out of date and is archived. `@fusionauth/angular-sdk` is currently maintained at https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-angular**
+
 An SDK for using FusionAuth in Angular applications.
 
 # Table of Contents
@@ -15,8 +17,6 @@ An SDK for using FusionAuth in Angular applications.
   -   [Service usage](#service-usage)
 
   -   [Known issues](#known-issues)
-
--   [Example App](#example-app)
 
 -   [Quickstart](#quickstart)
 

--- a/generated/README.adoc
+++ b/generated/README.adoc
@@ -1,3 +1,5 @@
+*This repo is out of date and is archived. `@fusionauth/angular-sdk` is currently maintained at https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-angular*
+
 An SDK for using FusionAuth in Angular applications.
 
 == Table of Contents
@@ -9,7 +11,6 @@ An SDK for using FusionAuth in Angular applications.
 * <<pre-built-buttons,Pre-built buttons>>
 * <<service-usage,Service usage>>
 * <<known-issues,Known issues>>
-* <<example-app,Example App>>
 * <<quickstart,Quickstart>>
 * <<documentation,Documentation>>
 * <<releases,Releases>>


### PR DESCRIPTION
## What is this PR and why do we need it?
#31 - Adding an archival note to the README. Once this PR is merged, this repo is ready to become archived, and we will be maintaining `@fusionauth/angular-sdk` from the [angular-sdk package within our monorepo](https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/angular-react) going forward.

#### Pre-Merge Checklist (if applicable)
-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.